### PR TITLE
Upgrade to the latest node on a different image

### DIFF
--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -1,7 +1,7 @@
 pipeline {
     agent {
         docker {
-            image 'node:6-alpine'
+            image 'mhart/alpine-node:11'
             args '-p 3000:3000 -p 5000:5000'
         }
     }


### PR DESCRIPTION
Running both the development branch and the production branch results in an error indicating 'sh: react-scripts: command not found'. This patch uses a docker image with the most updated node version (node 11) on Alpine Linux distribution.The issue is solved and Jenkins builds are made successfully.