### PR TITLE
Specify which version of npm should be used

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,5 +34,6 @@
       "last 1 firefox version",
       "last 1 safari version"
     ]
-  }
+  },
+  "packageManager": "npm@9.6.1"
 }


### PR DESCRIPTION
In case no npm version can be located, or the installed one is outdated, the version specified will be used to ensure everyone uses the same version.