### PR TITLE
Use a platform independent echo statement

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,7 +3,7 @@ pipeline {
     stages {
         stage('Build') {
             steps {
-                sh 'echo "Hello world!"'
+                echo 'Hello world!'
             }
         }
     }


### PR DESCRIPTION
CI jobs sometimes fail due to `agent any` that is allowed to choose a Windows agent.  When a Windows agent is chosen, the `sh` step fails.